### PR TITLE
Change backslashes in file paths to forward slashes.

### DIFF
--- a/IndustrialPark/ArchiveEditor/ArchiveEditor.cs
+++ b/IndustrialPark/ArchiveEditor/ArchiveEditor.cs
@@ -640,7 +640,7 @@ namespace IndustrialPark
                     foreach (uint u in CurrentlySelectedAssetIDs())
                         try
                         {
-                            File.WriteAllBytes(saveFileDialog.FileName + "\\" + archive.GetFromAssetID(u).AHDR.ADBG.assetName, archive.GetFromAssetID(u).Data);
+                            File.WriteAllBytes(saveFileDialog.FileName + "/" + archive.GetFromAssetID(u).AHDR.ADBG.assetName, archive.GetFromAssetID(u).Data);
                         }
                         catch (Exception ex)
                         {

--- a/IndustrialPark/ArchiveEditor/ArchiveEditorFunctions_IO.cs
+++ b/IndustrialPark/ArchiveEditor/ArchiveEditorFunctions_IO.cs
@@ -8,7 +8,7 @@ namespace IndustrialPark
     public partial class ArchiveEditorFunctions
     {
         public static string editorFilesFolder => Application.StartupPath +
-            "\\Resources\\IndustrialPark-EditorFiles\\IndustrialPark-EditorFiles-master\\";
+            "/Resources/IndustrialPark-EditorFiles/IndustrialPark-EditorFiles-master/";
 
         public void ExportHip(string fileName)
         {

--- a/IndustrialPark/ArchiveEditor/InternalEditors/InternalModelEditor.cs
+++ b/IndustrialPark/ArchiveEditor/InternalEditors/InternalModelEditor.cs
@@ -81,7 +81,7 @@ namespace IndustrialPark
                         var bitmaps = archive.GetTexturesAsBitmaps(asset.Textures);
                         ReadFileMethods.treatStuffAsByteArray = false;
                         foreach (string textureName in bitmaps.Keys)
-                            bitmaps[textureName].Save(folderName + "\\" + textureName + ".png", System.Drawing.Imaging.ImageFormat.Png);
+                            bitmaps[textureName].Save(folderName + "/" + textureName + ".png", System.Drawing.Imaging.ImageFormat.Png);
                     }
                 }
             }

--- a/IndustrialPark/ArchiveEditor/Other/TextureIOHelper.cs
+++ b/IndustrialPark/ArchiveEditor/Other/TextureIOHelper.cs
@@ -13,9 +13,9 @@ namespace IndustrialPark
 {
     public static class TextureIOHelper
     {
-        public static string txdGenFolder => Application.StartupPath + "\\Resources\\txdgen_1.0\\";
-        public static string tempGcTxdsDir => txdGenFolder + "Temp\\txds_gc\\";
-        public static string tempPcTxdsDir => txdGenFolder + "Temp\\txds_pc\\";
+        public static string txdGenFolder => Application.StartupPath + "/Resources/txdgen_1.0/";
+        public static string tempGcTxdsDir => txdGenFolder + "Temp/txds_gc/";
+        public static string tempPcTxdsDir => txdGenFolder + "Temp/txds_pc/";
         public static string pathToGcTXD => tempGcTxdsDir + "temp.txd";
         public static string pathToPcTXD => tempPcTxdsDir + "temp.txd";
 

--- a/IndustrialPark/MainForm/MainForm.cs
+++ b/IndustrialPark/MainForm/MainForm.cs
@@ -30,9 +30,9 @@ namespace IndustrialPark
             renderer = new SharpRenderer(renderPanel);
         }
         
-        public static string pathToSettings => Application.StartupPath + "\\ip_settings.json";
+        public static string pathToSettings => Application.StartupPath + "/ip_settings.json";
         private string currentProjectPath;
-        public string userTemplatesFolder => Application.StartupPath + "\\Resources\\UserTemplates\\";
+        public string userTemplatesFolder => Application.StartupPath + "/Resources/UserTemplates/";
 
         private void MainForm_Load(object sender, EventArgs e)
         {
@@ -49,7 +49,7 @@ namespace IndustrialPark
                 if (settings.CheckForUpdatesOnStartup && AutomaticUpdater.UpdateIndustrialPark(out _))
                 {
                     Close();
-                    System.Diagnostics.Process.Start(Application.StartupPath + "\\IndustrialPark.exe");
+                    System.Diagnostics.Process.Start(Application.StartupPath + "/IndustrialPark.exe");
                 }
                 
                 string[] args = Environment.GetCommandLineArgs();
@@ -216,7 +216,7 @@ namespace IndustrialPark
             if (AutomaticUpdater.UpdateIndustrialPark(out bool hasChecked))
             {
                 Close();
-                System.Diagnostics.Process.Start(Application.StartupPath + "\\IndustrialPark.exe");
+                System.Diagnostics.Process.Start(Application.StartupPath + "/IndustrialPark.exe");
             }
             else if (hasChecked)
                 MessageBox.Show("No update found.");

--- a/IndustrialPark/Other/AutomaticUpdater.cs
+++ b/IndustrialPark/Other/AutomaticUpdater.cs
@@ -40,12 +40,12 @@ namespace IndustrialPark
                         string updatedIPfileName = "IndustrialPark_" + updatedVersion.version.Replace('p', 'P') + ".zip";
                         string updatedIPURL = "https://github.com/igorseabra4/IndustrialPark/releases/download/" + updatedVersion.version + "/" + updatedIPfileName;
 
-                        string updatedIPfilePath = Application.StartupPath + "\\Resources\\" + updatedIPfileName;
+                        string updatedIPfilePath = Application.StartupPath + "/Resources/" + updatedIPfileName;
 
                         using (var webClient = new WebClient())
                             webClient.DownloadFile(updatedIPURL, updatedIPfilePath);
 
-                        string oldIPdestinationPath = Application.StartupPath + "\\IndustrialPark_old\\";
+                        string oldIPdestinationPath = Application.StartupPath + "/IndustrialPark_old/";
 
                         if (!Directory.Exists(oldIPdestinationPath))
                             Directory.CreateDirectory(oldIPdestinationPath);
@@ -53,30 +53,30 @@ namespace IndustrialPark
                         string[] directoryNames = new string[]
                         {
                                 "",
-                                "\\Resources",
-                                "\\Resources\\importvcolorobj",
-                                "\\Resources\\Models",
-                                "\\Resources\\SharpDX",
-                                "\\Resources\\txdgen_1.0",
-                                "\\Resources\\txdgen_1.0",
-                                "\\Resources\\txdgen_1.0\\LICENSES",
-                                "\\Resources\\txdgen_1.0\\LICENSES\\eirrepo",
-                                "\\Resources\\txdgen_1.0\\LICENSES\\libimagequant",
-                                "\\Resources\\txdgen_1.0\\LICENSES\\libjpeg",
-                                "\\Resources\\txdgen_1.0\\LICENSES\\libpng",
-                                "\\Resources\\txdgen_1.0\\LICENSES\\libsquish",
-                                "\\Resources\\txdgen_1.0\\LICENSES\\lzo-2.08",
-                                "\\Resources\\txdgen_1.0\\LICENSES\\pvrtextool",
-                                "\\Resources\\txdgen_1.0\\LICENSES\\rwtools",
-                                "\\runtimes\\",
-                                "\\runtimes\\linux-x64",
-                                "\\runtimes\\linux-x64\\native",
-                                "\\runtimes\\osx-x64",
-                                "\\runtimes\\osx-x64\\native",
-                                "\\runtimes\\win-x64",
-                                "\\runtimes\\win-x64\\native",
-                                "\\runtimes\\win-x86",
-                                "\\runtimes\\win-x86\\native",
+                                "/Resources",
+                                "/Resources/importvcolorobj",
+                                "/Resources/Models",
+                                "/Resources/SharpDX",
+                                "/Resources/txdgen_1.0",
+                                "/Resources/txdgen_1.0",
+                                "/Resources/txdgen_1.0/LICENSES",
+                                "/Resources/txdgen_1.0/LICENSES/eirrepo",
+                                "/Resources/txdgen_1.0/LICENSES/libimagequant",
+                                "/Resources/txdgen_1.0/LICENSES/libjpeg",
+                                "/Resources/txdgen_1.0/LICENSES/libpng",
+                                "/Resources/txdgen_1.0/LICENSES/libsquish",
+                                "/Resources/txdgen_1.0/LICENSES/lzo-2.08",
+                                "/Resources/txdgen_1.0/LICENSES/pvrtextool",
+                                "/Resources/txdgen_1.0/LICENSES/rwtools",
+                                "/runtimes/",
+                                "/runtimes/linux-x64",
+                                "/runtimes/linux-x64/native",
+                                "/runtimes/osx-x64",
+                                "/runtimes/osx-x64/native",
+                                "/runtimes/win-x64",
+                                "/runtimes/win-x64/native",
+                                "/runtimes/win-x86",
+                                "/runtimes/win-x86/native",
                         };
 
                         foreach (string localDirPath in directoryNames)
@@ -90,7 +90,7 @@ namespace IndustrialPark
                                     if (Path.GetExtension(previousFile).ToLower().Equals(".zip") || Path.GetExtension(previousFile).ToLower().Equals(".json"))
                                         continue;
 
-                                    string newFilePath = oldIPdestinationPath + localDirPath + "\\" + Path.GetFileName(previousFile);
+                                    string newFilePath = oldIPdestinationPath + localDirPath + "/" + Path.GetFileName(previousFile);
 
                                     if (File.Exists(newFilePath))
                                         File.Delete(newFilePath);
@@ -120,8 +120,8 @@ namespace IndustrialPark
             try
             {
                 string editorFilesZipURL = "https://github.com/igorseabra4/IndustrialPark-EditorFiles/archive/master.zip";
-                string destZipPath = Application.StartupPath + "\\Resources\\IndustrialPark-EditorFiles.zip";
-                string editorFilesFolder = Application.StartupPath + "\\Resources\\IndustrialPark-EditorFiles\\";
+                string destZipPath = Application.StartupPath + "/Resources/IndustrialPark-EditorFiles.zip";
+                string editorFilesFolder = Application.StartupPath + "/Resources/IndustrialPark-EditorFiles/";
 
                 MessageBox.Show("Will begin download of IndustrialPark-EditorFiles from GitHub to " + editorFilesFolder + ". Please wait as this might take a while. Any previously existing files in the folder will be overwritten.");
 

--- a/IndustrialPark/SharpDX/SharpRenderer.cs
+++ b/IndustrialPark/SharpDX/SharpRenderer.cs
@@ -105,10 +105,10 @@ namespace IndustrialPark
             if (whiteDefault != null)
             {
                 if (whiteDefault.IsDisposed)
-                    whiteDefault = device.LoadTextureFromFile(Application.StartupPath + "\\Resources\\WhiteDefault.png");
+                    whiteDefault = device.LoadTextureFromFile(Application.StartupPath + "/Resources/WhiteDefault.png");
             }
             else
-                whiteDefault = device.LoadTextureFromFile(Application.StartupPath + "\\Resources\\WhiteDefault.png");
+                whiteDefault = device.LoadTextureFromFile(Application.StartupPath + "/Resources/WhiteDefault.png");
         }
 
         public static SharpMesh Cube { get; private set; }

--- a/IndustrialParkRandomizer/Forms/RandomizerMenu.cs
+++ b/IndustrialParkRandomizer/Forms/RandomizerMenu.cs
@@ -21,7 +21,7 @@ namespace IndustrialPark.Randomizer
                 if (settings.CheckForUpdatesOnStartup && AutomaticUpdater.UpdateIndustrialPark(out _))
                 {
                     Close();
-                    System.Diagnostics.Process.Start(Application.StartupPath + "\\Randomizer.exe");
+                    System.Diagnostics.Process.Start(Application.StartupPath + "/Randomizer.exe");
                 }
             }
             else

--- a/IndustrialParkRandomizer/Randomizer/RandomizableArchive.cs
+++ b/IndustrialParkRandomizer/Randomizer/RandomizableArchive.cs
@@ -962,7 +962,7 @@ namespace IndustrialPark.Randomizer
 
         private void ProgImportHip(string folderName, string fileName)
         {
-            string path = editorFilesFolder + "BattleForBikiniBottom\\" + platform.ToString() + "\\" + folderName + "\\" + fileName;
+            string path = editorFilesFolder + "BattleForBikiniBottom/" + platform.ToString() + "/" + folderName + "/" + fileName;
 
             if (!enemyHipDict.ContainsKey(fileName))
                 enemyHipDict.Add(fileName, new HipFile(path));

--- a/IndustrialParkRandomizer/Randomizer/Randomizer.cs
+++ b/IndustrialParkRandomizer/Randomizer/Randomizer.cs
@@ -261,7 +261,7 @@ namespace IndustrialPark.Randomizer
             // Perform things on boot.hip
             if (flags.HasFlag(RandomizerFlags.Music) || settings.bootHipLodtMulti)
             {
-                string bootPath = rootDir + "\\boot.hip";
+                string bootPath = rootDir + "/boot.hip";
                 if (File.Exists(bootPath))
                 {
                     var boot = new RandomizableArchive();
@@ -365,7 +365,7 @@ namespace IndustrialPark.Randomizer
                 message += "\n* A warps_log.txt file with the result of the Warps randomizer was saved to your root folder. Don't look at that file, it spoils the fun.";
             }
 
-            File.WriteAllText(rootDir + "\\settings.json", JsonConvert.SerializeObject(this, Formatting.Indented));
+            File.WriteAllText(rootDir + "/settings.json", JsonConvert.SerializeObject(this, Formatting.Indented));
             message += "\n* The settings.json file with the settings used was saved to your root folder.";
 
             MessageBox.Show(message);
@@ -398,12 +398,12 @@ namespace IndustrialPark.Randomizer
             namesForBoot.Remove("S006");
 
             string[] ini;
-            string filePath = rootDir + "\\sb.ini";
+            string filePath = rootDir + "/sb.ini";
             if (File.Exists(filePath))
                 ini = File.ReadAllLines(filePath);
             else
             {
-                filePath = rootDir + "\\sd2.ini";
+                filePath = rootDir + "/sd2.ini";
                 if (File.Exists(filePath))
                     ini = File.ReadAllLines(filePath);
                 else
@@ -450,7 +450,7 @@ namespace IndustrialPark.Randomizer
 
         private void WriteLog(List<(string, string, string)> warpRandomizerOutput)
         {
-            using (StreamWriter streamWriter = new StreamWriter(new FileStream(rootDir + "\\warps_log.txt", FileMode.Create)))
+            using (StreamWriter streamWriter = new StreamWriter(new FileStream(rootDir + "/warps_log.txt", FileMode.Create)))
             {
                 HashSet<string> uniqueNames = new HashSet<string>();
                 foreach (var s in warpRandomizerOutput)


### PR DESCRIPTION
This fixes one of the issues in #10, where the backslashes in file paths will not work properly on Linux. 

Most of this was done by running `sed -i 's@\\\\@/@g **/*.c` on the repo and reverting anything that should not be changed.

This should work as a temporary solution for now, but in the future using functions from [`System.IO.Path`](https://docs.microsoft.com/en-us/dotnet/api/system.io.path) will be a better solution.

You'll need to compile test this yourself as I have no way of doing so due to the library requirements.