### PR TITLE
Randomizer: Fix the folder picker on mono.

### DIFF
--- a/IndustrialParkRandomizer/Forms/RandomizerMenu.cs
+++ b/IndustrialParkRandomizer/Forms/RandomizerMenu.cs
@@ -69,12 +69,17 @@ namespace IndustrialPark.Randomizer
             bool success = false;
             try
             {
-                using (CommonOpenFileDialog openFile = new CommonOpenFileDialog() { Title = "Please choose your backup files directory.", IsFolderPicker = true })
-                    if (openFile.ShowDialog() == CommonFileDialogResult.Ok)
-                    {
-                        backupDir = openFile.FileName;
-                        success = true;
-                    }
+                void WindowsFolderPicker()
+                {
+                    using (CommonOpenFileDialog openFile = new CommonOpenFileDialog() { Title = "Please choose your backup files directory.", IsFolderPicker = true })
+                        if (openFile.ShowDialog() == CommonFileDialogResult.Ok)
+                        {
+                            backupDir = openFile.FileName;
+                            success = true;
+                        }
+                }
+
+                WindowsFolderPicker();
             }
             catch
             {
@@ -113,12 +118,16 @@ namespace IndustrialPark.Randomizer
             bool success = false;
             try
             {
-                using (CommonOpenFileDialog openFile = new CommonOpenFileDialog() { Title = "Please choose your game root (files) directory.", IsFolderPicker = true })
-                    if (openFile.ShowDialog() == CommonFileDialogResult.Ok)
-                    {
-                        randomizer.SetRootDir(openFile.FileName);
-                        success = true;
-                    }
+                void WindowsFolderPicker() {
+                    using (CommonOpenFileDialog openFile = new CommonOpenFileDialog() { Title = "Please choose your game root (files) directory.", IsFolderPicker = true })
+                        if (openFile.ShowDialog() == CommonFileDialogResult.Ok)
+                        {
+                            randomizer.SetRootDir(openFile.FileName);
+                            success =  true;
+                        }
+                }
+
+                WindowsFolderPicker();
             }
             catch
             {


### PR DESCRIPTION
Using a try-catch here isn't sufficient because DLLs are lazy loaded on a
per function basis. Using a nested function will allow mono to catch the
error and fall back to the default folder picker.