### PR TITLE
Discord Rich Presence Functionality

### DIFF
--- a/IndustrialPark/App.config
+++ b/IndustrialPark/App.config
@@ -4,6 +4,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
   </startup>
   <runtime>
+    <legacyCorruptedStateExceptionsPolicy enabled="false"/>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />

--- a/IndustrialPark/IndustrialPark.csproj
+++ b/IndustrialPark/IndustrialPark.csproj
@@ -72,6 +72,9 @@
     <Reference Include="AssimpNet, Version=4.1.0.0, Culture=neutral, PublicKeyToken=0d51b391f59f42a6, processorArchitecture=MSIL">
       <HintPath>..\packages\AssimpNet.4.1.0\lib\net40\AssimpNet.dll</HintPath>
     </Reference>
+    <Reference Include="DiscordRPC, Version=1.0.150.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DiscordRichPresence.1.0.150\lib\net35\DiscordRPC.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAPICodePack-Core.1.1.2\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
     </Reference>

--- a/IndustrialPark/MainForm/MainForm.Designer.cs
+++ b/IndustrialPark/MainForm/MainForm.Designer.cs
@@ -62,6 +62,7 @@ namespace IndustrialPark
             this.wireframeFToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.useLODTForRenderingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.usePIPTForRenderingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.discordRichPresenceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hideInvisibleMeshesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.updateReferencesOnCopyPasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pLATPreviewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -72,6 +73,7 @@ namespace IndustrialPark
             this.saveAllOpenHIPsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.runGameF5ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.stopSoundToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportSceneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
             this.manageUserTemplatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.templatesPersistentShiniesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -132,7 +134,7 @@ namespace IndustrialPark
             this.toolStripMenuItem_Templates = new System.Windows.Forms.ToolStripMenuItem();
             this.userTemplateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripComboBoxUserTemplate = new System.Windows.Forms.ToolStripComboBox();
-            this.exportSceneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.timer1 = new System.Windows.Forms.Timer(this.components);
             this.menuStrip1.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.contextMenuStripMain.SuspendLayout();
@@ -253,6 +255,7 @@ namespace IndustrialPark
             this.wireframeFToolStripMenuItem,
             this.useLODTForRenderingToolStripMenuItem,
             this.usePIPTForRenderingToolStripMenuItem,
+            this.discordRichPresenceToolStripMenuItem,
             this.hideInvisibleMeshesToolStripMenuItem,
             this.updateReferencesOnCopyPasteToolStripMenuItem,
             this.pLATPreviewToolStripMenuItem,
@@ -389,6 +392,13 @@ namespace IndustrialPark
             this.usePIPTForRenderingToolStripMenuItem.Text = "Use PIPT For Rendering";
             this.usePIPTForRenderingToolStripMenuItem.Click += new System.EventHandler(this.UsePIPTForRenderingToolStripMenuItem_Click);
             // 
+            // discordRichPresenceToolStripMenuItem
+            // 
+            this.discordRichPresenceToolStripMenuItem.Name = "discordRichPresenceToolStripMenuItem";
+            this.discordRichPresenceToolStripMenuItem.Size = new System.Drawing.Size(253, 22);
+            this.discordRichPresenceToolStripMenuItem.Text = "Discord Rich Presence";
+            this.discordRichPresenceToolStripMenuItem.Click += new System.EventHandler(this.discordRichPresenceToolStripMenuItem_Click);
+            // 
             // hideInvisibleMeshesToolStripMenuItem
             // 
             this.hideInvisibleMeshesToolStripMenuItem.Name = "hideInvisibleMeshesToolStripMenuItem";
@@ -474,6 +484,13 @@ namespace IndustrialPark
             this.stopSoundToolStripMenuItem.Size = new System.Drawing.Size(271, 22);
             this.stopSoundToolStripMenuItem.Text = "Stop Sound";
             this.stopSoundToolStripMenuItem.Click += new System.EventHandler(this.stopSoundToolStripMenuItem_Click);
+            // 
+            // exportSceneToolStripMenuItem
+            // 
+            this.exportSceneToolStripMenuItem.Name = "exportSceneToolStripMenuItem";
+            this.exportSceneToolStripMenuItem.Size = new System.Drawing.Size(271, 22);
+            this.exportSceneToolStripMenuItem.Text = "Export Scene...";
+            this.exportSceneToolStripMenuItem.Click += new System.EventHandler(this.exportSceneToolStripMenuItem_Click);
             // 
             // toolStripSeparator8
             // 
@@ -598,7 +615,7 @@ namespace IndustrialPark
             this.levelModelToolStripMenuItem.Checked = true;
             this.levelModelToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.levelModelToolStripMenuItem.Name = "levelModelToolStripMenuItem";
-            this.levelModelToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.levelModelToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.levelModelToolStripMenuItem.Text = "BSP/JSP";
             this.levelModelToolStripMenuItem.Click += new System.EventHandler(this.levelModelToolStripMenuItem_Click);
             // 
@@ -607,7 +624,7 @@ namespace IndustrialPark
             this.bOULToolStripMenuItem.Checked = true;
             this.bOULToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.bOULToolStripMenuItem.Name = "bOULToolStripMenuItem";
-            this.bOULToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.bOULToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.bOULToolStripMenuItem.Text = "BOUL";
             this.bOULToolStripMenuItem.Click += new System.EventHandler(this.bOULToolStripMenuItem_Click);
             // 
@@ -616,7 +633,7 @@ namespace IndustrialPark
             this.bUTNToolStripMenuItem.Checked = true;
             this.bUTNToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.bUTNToolStripMenuItem.Name = "bUTNToolStripMenuItem";
-            this.bUTNToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.bUTNToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.bUTNToolStripMenuItem.Text = "BUTN";
             this.bUTNToolStripMenuItem.Click += new System.EventHandler(this.bUTNToolStripMenuItem_Click);
             // 
@@ -625,7 +642,7 @@ namespace IndustrialPark
             this.cAMToolStripMenuItem.Checked = true;
             this.cAMToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cAMToolStripMenuItem.Name = "cAMToolStripMenuItem";
-            this.cAMToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.cAMToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.cAMToolStripMenuItem.Text = "CAM";
             this.cAMToolStripMenuItem.Click += new System.EventHandler(this.cAMToolStripMenuItem_Click);
             // 
@@ -634,7 +651,7 @@ namespace IndustrialPark
             this.dSTRToolStripMenuItem.Checked = true;
             this.dSTRToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.dSTRToolStripMenuItem.Name = "dSTRToolStripMenuItem";
-            this.dSTRToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.dSTRToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.dSTRToolStripMenuItem.Text = "DSTR";
             this.dSTRToolStripMenuItem.Click += new System.EventHandler(this.dSTRToolStripMenuItem_Click);
             // 
@@ -643,7 +660,7 @@ namespace IndustrialPark
             this.dUPCToolStripMenuItem.Checked = true;
             this.dUPCToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.dUPCToolStripMenuItem.Name = "dUPCToolStripMenuItem";
-            this.dUPCToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.dUPCToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.dUPCToolStripMenuItem.Text = "DUPC";
             this.dUPCToolStripMenuItem.Click += new System.EventHandler(this.dUPCToolStripMenuItem_Click);
             // 
@@ -652,7 +669,7 @@ namespace IndustrialPark
             this.dYNAToolStripMenuItem.Checked = true;
             this.dYNAToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.dYNAToolStripMenuItem.Name = "dYNAToolStripMenuItem";
-            this.dYNAToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.dYNAToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.dYNAToolStripMenuItem.Text = "DYNA";
             this.dYNAToolStripMenuItem.Click += new System.EventHandler(this.dYNAToolStripMenuItem_Click);
             // 
@@ -661,7 +678,7 @@ namespace IndustrialPark
             this.eGENToolStripMenuItem.Checked = true;
             this.eGENToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.eGENToolStripMenuItem.Name = "eGENToolStripMenuItem";
-            this.eGENToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.eGENToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.eGENToolStripMenuItem.Text = "EGEN";
             this.eGENToolStripMenuItem.Click += new System.EventHandler(this.eGENToolStripMenuItem_Click);
             // 
@@ -670,7 +687,7 @@ namespace IndustrialPark
             this.hANGToolStripMenuItem.Checked = true;
             this.hANGToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.hANGToolStripMenuItem.Name = "hANGToolStripMenuItem";
-            this.hANGToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.hANGToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.hANGToolStripMenuItem.Text = "HANG";
             this.hANGToolStripMenuItem.Click += new System.EventHandler(this.hANGToolStripMenuItem_Click);
             // 
@@ -679,7 +696,7 @@ namespace IndustrialPark
             this.lITEToolStripMenuItem.Checked = true;
             this.lITEToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.lITEToolStripMenuItem.Name = "lITEToolStripMenuItem";
-            this.lITEToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.lITEToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.lITEToolStripMenuItem.Text = "LITE";
             this.lITEToolStripMenuItem.Click += new System.EventHandler(this.lITEToolStripMenuItem_Click);
             // 
@@ -688,7 +705,7 @@ namespace IndustrialPark
             this.mRKRToolStripMenuItem.Checked = true;
             this.mRKRToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.mRKRToolStripMenuItem.Name = "mRKRToolStripMenuItem";
-            this.mRKRToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.mRKRToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.mRKRToolStripMenuItem.Text = "MRKR";
             this.mRKRToolStripMenuItem.Click += new System.EventHandler(this.mRKRToolStripMenuItem_Click);
             // 
@@ -697,7 +714,7 @@ namespace IndustrialPark
             this.mVPTToolStripMenuItem.Checked = true;
             this.mVPTToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.mVPTToolStripMenuItem.Name = "mVPTToolStripMenuItem";
-            this.mVPTToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.mVPTToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.mVPTToolStripMenuItem.Text = "MVPT";
             this.mVPTToolStripMenuItem.Click += new System.EventHandler(this.mVPTToolStripMenuItem_Click);
             // 
@@ -706,7 +723,7 @@ namespace IndustrialPark
             this.pENDToolStripMenuItem.Checked = true;
             this.pENDToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.pENDToolStripMenuItem.Name = "pENDToolStripMenuItem";
-            this.pENDToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.pENDToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.pENDToolStripMenuItem.Text = "PEND";
             this.pENDToolStripMenuItem.Click += new System.EventHandler(this.pENDToolStripMenuItem_Click);
             // 
@@ -715,7 +732,7 @@ namespace IndustrialPark
             this.pKUPToolStripMenuItem.Checked = true;
             this.pKUPToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.pKUPToolStripMenuItem.Name = "pKUPToolStripMenuItem";
-            this.pKUPToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.pKUPToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.pKUPToolStripMenuItem.Text = "PKUP";
             this.pKUPToolStripMenuItem.Click += new System.EventHandler(this.pKUPToolStripMenuItem_Click);
             // 
@@ -724,7 +741,7 @@ namespace IndustrialPark
             this.pLATToolStripMenuItem.Checked = true;
             this.pLATToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.pLATToolStripMenuItem.Name = "pLATToolStripMenuItem";
-            this.pLATToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.pLATToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.pLATToolStripMenuItem.Text = "PLAT";
             this.pLATToolStripMenuItem.Click += new System.EventHandler(this.pLATToolStripMenuItem_Click);
             // 
@@ -733,7 +750,7 @@ namespace IndustrialPark
             this.pLYRToolStripMenuItem.Checked = true;
             this.pLYRToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.pLYRToolStripMenuItem.Name = "pLYRToolStripMenuItem";
-            this.pLYRToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.pLYRToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.pLYRToolStripMenuItem.Text = "PLYR";
             this.pLYRToolStripMenuItem.Click += new System.EventHandler(this.pLYRToolStripMenuItem_Click);
             // 
@@ -742,7 +759,7 @@ namespace IndustrialPark
             this.sDFXToolStripMenuItem.Checked = true;
             this.sDFXToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.sDFXToolStripMenuItem.Name = "sDFXToolStripMenuItem";
-            this.sDFXToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.sDFXToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.sDFXToolStripMenuItem.Text = "SDFX";
             this.sDFXToolStripMenuItem.Click += new System.EventHandler(this.sDFXToolStripMenuItem_Click);
             // 
@@ -751,7 +768,7 @@ namespace IndustrialPark
             this.sFXToolStripMenuItem.Checked = true;
             this.sFXToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.sFXToolStripMenuItem.Name = "sFXToolStripMenuItem";
-            this.sFXToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.sFXToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.sFXToolStripMenuItem.Text = "SFX";
             this.sFXToolStripMenuItem.Click += new System.EventHandler(this.sFXToolStripMenuItem_Click);
             // 
@@ -760,7 +777,7 @@ namespace IndustrialPark
             this.sPLNToolStripMenuItem.Checked = true;
             this.sPLNToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.sPLNToolStripMenuItem.Name = "sPLNToolStripMenuItem";
-            this.sPLNToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.sPLNToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.sPLNToolStripMenuItem.Text = "SPLN";
             this.sPLNToolStripMenuItem.Click += new System.EventHandler(this.sPLNToolStripMenuItem_Click);
             // 
@@ -769,7 +786,7 @@ namespace IndustrialPark
             this.sIMPToolStripMenuItem.Checked = true;
             this.sIMPToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.sIMPToolStripMenuItem.Name = "sIMPToolStripMenuItem";
-            this.sIMPToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.sIMPToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.sIMPToolStripMenuItem.Text = "SIMP";
             this.sIMPToolStripMenuItem.Click += new System.EventHandler(this.sIMPToolStripMenuItem_Click);
             // 
@@ -778,7 +795,7 @@ namespace IndustrialPark
             this.tRIGToolStripMenuItem.Checked = true;
             this.tRIGToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.tRIGToolStripMenuItem.Name = "tRIGToolStripMenuItem";
-            this.tRIGToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.tRIGToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.tRIGToolStripMenuItem.Text = "TRIG";
             this.tRIGToolStripMenuItem.Click += new System.EventHandler(this.tRIGToolStripMenuItem_Click);
             // 
@@ -787,7 +804,7 @@ namespace IndustrialPark
             this.uIToolStripMenuItem.Checked = true;
             this.uIToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.uIToolStripMenuItem.Name = "uIToolStripMenuItem";
-            this.uIToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.uIToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.uIToolStripMenuItem.Text = "UI";
             this.uIToolStripMenuItem.Click += new System.EventHandler(this.uIToolStripMenuItem_Click);
             // 
@@ -796,7 +813,7 @@ namespace IndustrialPark
             this.uIFTToolStripMenuItem.Checked = true;
             this.uIFTToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.uIFTToolStripMenuItem.Name = "uIFTToolStripMenuItem";
-            this.uIFTToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.uIFTToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.uIFTToolStripMenuItem.Text = "UIFT";
             this.uIFTToolStripMenuItem.Click += new System.EventHandler(this.uIFTToolStripMenuItem_Click);
             // 
@@ -805,26 +822,26 @@ namespace IndustrialPark
             this.vILToolStripMenuItem.Checked = true;
             this.vILToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.vILToolStripMenuItem.Name = "vILToolStripMenuItem";
-            this.vILToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.vILToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.vILToolStripMenuItem.Text = "VIL";
             this.vILToolStripMenuItem.Click += new System.EventHandler(this.vILToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(177, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(165, 6);
             // 
             // uIModeToolStripMenuItem
             // 
             this.uIModeToolStripMenuItem.Name = "uIModeToolStripMenuItem";
-            this.uIModeToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.uIModeToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.uIModeToolStripMenuItem.Text = "UI Mode (U)";
             this.uIModeToolStripMenuItem.Click += new System.EventHandler(this.uIModeToolStripMenuItem_Click);
             // 
             // uIModeAutoSizeToolStripMenuItem
             // 
             this.uIModeAutoSizeToolStripMenuItem.Name = "uIModeAutoSizeToolStripMenuItem";
-            this.uIModeAutoSizeToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.uIModeAutoSizeToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.uIModeAutoSizeToolStripMenuItem.Text = "UI Mode AutoSize";
             this.uIModeAutoSizeToolStripMenuItem.Click += new System.EventHandler(this.uIModeAutoSizeToolStripMenuItem_Click);
             // 
@@ -987,12 +1004,10 @@ namespace IndustrialPark
             this.toolStripComboBoxUserTemplate.Size = new System.Drawing.Size(160, 23);
             this.toolStripComboBoxUserTemplate.SelectedIndexChanged += new System.EventHandler(this.toolStripComboBoxUserTemplate_SelectedIndexChanged);
             // 
-            // exportSceneToolStripMenuItem
+            // timer1
             // 
-            this.exportSceneToolStripMenuItem.Name = "exportSceneToolStripMenuItem";
-            this.exportSceneToolStripMenuItem.Size = new System.Drawing.Size(271, 22);
-            this.exportSceneToolStripMenuItem.Text = "Export Scene...";
-            this.exportSceneToolStripMenuItem.Click += new System.EventHandler(this.exportSceneToolStripMenuItem_Click);
+            this.timer1.Interval = 1000;
+            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
             // 
             // MainForm
             // 
@@ -1105,6 +1120,7 @@ namespace IndustrialPark
         private ToolStripSeparator toolStripSeparator6;
         private ToolStripMenuItem hideHelpInAssetDataEditorsToolStripMenuItem;
         private ToolStripMenuItem usePIPTForRenderingToolStripMenuItem;
+        private ToolStripMenuItem discordRichPresenceToolStripMenuItem;
         private ToolStripMenuItem toolsToolStripMenuItem;
         private ToolStripMenuItem saveAllOpenHIPsToolStripMenuItem;
         private ToolStripMenuItem manageUserTemplatesToolStripMenuItem;
@@ -1129,6 +1145,7 @@ namespace IndustrialPark
         private ToolStripMenuItem sPLNToolStripMenuItem;
         private ToolStripMenuItem dYNASearchToolStripMenuItem;
         private ToolStripMenuItem exportSceneToolStripMenuItem;
+        private Timer timer1;
     }
 }
 

--- a/IndustrialPark/MainForm/MainForm.resx
+++ b/IndustrialPark/MainForm/MainForm.resx
@@ -126,6 +126,9 @@
   <metadata name="contextMenuStripMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>248, 17</value>
   </metadata>
+  <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>424, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/IndustrialPark/Other/IPSettings.cs
+++ b/IndustrialPark/Other/IPSettings.cs
@@ -9,6 +9,7 @@
 
         public bool renderBasedOnLodt = false;
         public bool renderBasedOnPipt = true;
+        public bool discordRichPresence = false;
         public bool dontDrawInvisible = false;
 
         public bool updateReferencesOnCopy = true;

--- a/IndustrialPark/packages.config
+++ b/IndustrialPark/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AssimpNet" version="4.1.0" targetFramework="net461" />
+  <package id="DiscordRichPresence" version="1.0.150" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="SharpDX" version="4.2.0" targetFramework="net461" />
   <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net461" />


### PR DESCRIPTION
Adds functionality with Discord to display a Rich Presence for the user. Toggles on and off from the options dropdown and displays the hip/hop you're currently working on. Note that it uses my own Discord application ID for the rich presence, it can be replaced at line 963 on MainForm.cs as long as the name of the application is Industrial Park and there is a photo named "icon".
![image](https://user-images.githubusercontent.com/68174586/87863255-33e87000-c927-11ea-91b6-430b49d04c2f.png)
