### PR TITLE
Update Battlepedia dead links

### DIFF
--- a/IndustrialPark/MainForm/AboutBox.cs
+++ b/IndustrialPark/MainForm/AboutBox.cs
@@ -85,7 +85,7 @@ namespace IndustrialPark
             System.Diagnostics.Process.Start(WikiLink);
         }
 
-        public static string WikiLink => "https://battlepedia.org/";
+        public static string WikiLink => "https://heavyironmodding.org";
 
         private void button3_Click(object sender, EventArgs e)
         {

--- a/IndustrialPark/MainForm/AboutBox.resx
+++ b/IndustrialPark/MainForm/AboutBox.resx
@@ -1454,6 +1454,6 @@ External tools used:
 - TxdGen
 - vgmstream
 
-For questions, suggestions, problems or any other reasons you can contact me at Battlepedia, GitHub, YouTube, or even better, on Discord: please join the BFBB Modding server. ~igorseabra4</value>
+For questions, suggestions, problems or any other reasons you can contact me at the Heavy Iron Modding Wiki, GitHub, YouTube, or even better, on Discord: please join the Heavy Iron Modding server. ~igorseabra4</value>
   </data>
 </root>

--- a/IndustrialPark/MainForm/AboutBox.resx
+++ b/IndustrialPark/MainForm/AboutBox.resx
@@ -1446,7 +1446,7 @@ Additional credits go to:
 - Dark
 - MinecraftFreak73
 - Seil
-- Suprnova123
+- Suprnova
 - TetraxZ
 and other members of the games' online communities for contributions on findings and code
 

--- a/IndustrialPark/MainForm/MainForm.cs
+++ b/IndustrialPark/MainForm/MainForm.cs
@@ -61,7 +61,7 @@ namespace IndustrialPark
                     System.Diagnostics.Process.Start(Application.StartupPath + "/IndustrialPark.exe");
                     return;
                 }
-                MessageBox.Show("It appears this is your first time using Industrial Park.\nPlease consult the documentation on the BFBB Modding Wiki to understand how to use the tool if you haven't already.\nAlso, be sure to check individual asset pages if you're not sure what one of them or their settings do.");
+                MessageBox.Show("It appears this is your first time using Industrial Park.\nPlease consult the documentation on the Heavy Iron Modding Wiki to understand how to use the tool if you haven't already.\nAlso, be sure to check individual asset pages if you're not sure what one of them or their settings do.");
                 Program.AboutBox.Show();
             }
 
@@ -819,7 +819,7 @@ namespace IndustrialPark
                 "Ctrl + Right click and drag to pan(move view up, left, down, right)\n" +
                 "Mouse mode(Z): similar to a first person camera.The view rotates automatically as you move the mouse.Use the keyboard to move around.\n" +
                 "\n" +
-                "Please consult the Industrial Park user guide on Battlepedia for more information");
+                "Please consult the Industrial Park user guide on the Heavy Iron Modding Wiki for more information");
         }
 
         private SharpDX.Rectangle ViewRectangle => new SharpDX.Rectangle(

--- a/IndustrialParkRandomizer/Randomizer/RandomizerMenu.cs
+++ b/IndustrialParkRandomizer/Randomizer/RandomizerMenu.cs
@@ -32,7 +32,7 @@ namespace IndustrialPark.Randomizer
             }
             else
             {
-                MessageBox.Show("It appears this is your first time using Industrial Park's Randomizer.\nPlease consult the documentation on the BFBB Modding Wiki to understand how to use the tool if you haven't already.");
+                MessageBox.Show("It appears this is your first time using Industrial Park's Randomizer.\nPlease consult the documentation on the Heavy Iron Modding Wiki to understand how to use the tool if you haven't already.");
 
                 checkForUpdatesOnStartupToolStripMenuItem.Checked = true;
 
@@ -185,7 +185,7 @@ namespace IndustrialPark.Randomizer
 
         private void ButtonHelp_Click(object sender, EventArgs e)
         {
-            System.Diagnostics.Process.Start("https://battlepedia.org/Randomizer");
+            System.Diagnostics.Process.Start("https://heavyironmodding.org/wiki/Randomizer");
         }
 
         private void buttonReset_Click(object sender, EventArgs e)

--- a/readme.md
+++ b/readme.md
@@ -16,4 +16,4 @@ for the following platforms:
 
 The tool (whose namesake is one of the levels in Battle For Bikini Bottom) can create, open, display, extract data from, edit and save the HIP/HOP archive files used in the games and contains multiple functions to aid on custom level creation; it's essentially a very fancy GUI for the [HipHopFile library](https://github.com/igorseabra4/HipHopTool). It was used by video game developer [Purple Lamp Studios](https://www.purplelamp.com/) during the development of [Spongebob Squarepants: Battle For Bikini Bottom - Rehydrated](https://www.purplelamp.com/projects/spongebob-squarepants-rehydrated/) to aid on extracting data from the original game.
 
-Please see the project's [page on the Battlepedia wiki](https://battlepedia.org/Industrial_Park_(level_editor)) for additional information, including the links to the complete user guide/tutorials.
+Please see the project's [page on the Heavy Iron Modding wiki](https://heavyironmodding.org/wiki/Industrial_Park_(level_editor)) for additional information, including the links to the complete user guide/tutorials.


### PR DESCRIPTION
Since the migration of wiki content from Battlepedia to Heavy Iron Modding, Battlepedia has become a dead link, and thus all links should be changed to reflect the new wiki. Additionally, any references to the "BFBB Modding" and "Battlepedia" should be updated to Heavy Iron Modding, to reflect the new server name and the new wiki respectively.