### PR TITLE
Specific wiki page for DYNA assets

### DIFF
--- a/IndustrialPark/ArchiveEditor/InternalEditors/InternalAssetEditor.cs
+++ b/IndustrialPark/ArchiveEditor/InternalEditors/InternalAssetEditor.cs
@@ -42,7 +42,12 @@ namespace IndustrialPark
 
             Button buttonHelp = new Button() { Dock = DockStyle.Fill, Text = "Open Wiki Page", AutoSize = true };
             buttonHelp.Click += (object sender, EventArgs e) =>
-                System.Diagnostics.Process.Start(AboutBox.WikiLink + asset.assetType.GetCode().ToString());
+            {
+                string wikiPath = asset.assetType.GetCode().ToString();
+                if (wikiPath == "DYNA")
+                    wikiPath += $"/{asset.TypeString}";
+                System.Diagnostics.Process.Start(AboutBox.WikiLink + wikiPath);
+            };
             tableLayoutPanel1.Controls.Add(buttonHelp, 0, tableLayoutPanel1.RowCount - 1);
 
             Button buttonFindCallers = new Button() { Dock = DockStyle.Fill, Text = "Find Who Targets Me", AutoSize = true };


### PR DESCRIPTION
Previously, DYNA assets would open to `https://heavyironmodding.org/wiki/DYNA`, despite the fact that every "skew" of DYNA assets have their own page on the wiki. Now, each asset will appropriately link to their own page. For example, a Race Timer DYNA will now open `./DYNA/game_object:RaceTimer`. I didn't test every type of DYNA asset, but it seems to be a 1:1 mapping between the internal ID of the asset and its corresponding wiki page (even ones with special characters like spaces), and the limited tests I did worked perfectly.

It's important to note that the wiki buttons on all editors still omit the `EvilEngine/` prefix in the URL (based on the AboutBox's wiki URL). The links still work, since HIM has redirects for all of those pages, but it's probably better practice to implement the full path eventually.