### PR TITLE
DiscordRPC rework and logging hotfix

### DIFF
--- a/IndustrialPark/MainForm/MainForm.cs
+++ b/IndustrialPark/MainForm/MainForm.cs
@@ -262,7 +262,7 @@ namespace IndustrialPark
             }
 
             // updates presence so that it doesn't get stuck on the previously focused window name
-            DiscordRPCController.setPresence("a project");
+            DiscordRPCController.setPresence(idling: true);
 
             currentProjectPath = null;
             ApplyProject(new ProjectJson());
@@ -283,7 +283,7 @@ namespace IndustrialPark
             }
 
             // updates presence so that it doesn't get stuck on the previously focused window name
-            DiscordRPCController.setPresence("a project");
+            DiscordRPCController.setPresence(idling: true);
 
             OpenFileDialog openFile = new OpenFileDialog()
             { Filter = "JSON files|*.json" };

--- a/IndustrialPark/Other/DiscordRPCController.cs
+++ b/IndustrialPark/Other/DiscordRPCController.cs
@@ -1,27 +1,35 @@
-﻿using DiscordRPC;
-using DiscordRPC.Logging;
-using System;
-using System.Runtime.InteropServices;
-using System.Text;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using DiscordRPC;
+using HipHopFile;
 
 namespace IndustrialPark
 {
     public static class DiscordRPCController
     {
-        [DllImport("user32.dll")]
-        private static extern IntPtr GetForegroundWindow();
-        [DllImport("user32.dll")]
-        static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
-
         public static DiscordRpcClient client;
 
         public static System.Windows.Forms.Timer timer1;
+
+        public static List<ArchiveEditor> archiveEditors = Program.MainForm.archiveEditors;
+
+        public static string currentArchiveEditor = string.Empty;
+
+        public static bool alreadyIdling = false;
+
+        public static Timestamps currentTimestamp = null;
 
         internal static void ToggleDiscordRichPresence(bool value)
         {
             if (value)
             {
-                Initialize();
+                try
+                {
+                    Initialize();
+                }
+                catch { }
             }
             else
             {
@@ -29,10 +37,10 @@ namespace IndustrialPark
                 {
                     if (client != null)
                         client.Dispose();
-                    if (timer1 != null)
-                        timer1.Enabled = false;
                 }
                 catch { }
+                if (timer1 != null)
+                    timer1.Enabled = false;
             }
         }
 
@@ -44,30 +52,106 @@ namespace IndustrialPark
             };
             timer1.Tick += timer1_Tick;
 
-            /*this application ID is assigned to Suprnova#0001 on Discord
-             it can be replaced with any other application ID as long as the name is "Industrial Park" and the image of the logo has the name of "icon"*/
-            client = new DiscordRpcClient("734104261876514836")
-            {
-                Logger = new ConsoleLogger() { Level = LogLevel.Warning }
-            };
+            // this application ID is assigned to Suprnova#0001 on Discord
+            // it can be replaced with any other application ID as long as 
+            // the name is "Industrial Park" and the image of the logo has 
+            // the name of "icon"
+            client = new DiscordRpcClient("734104261876514836");
             client.Initialize();
             timer1.Start();
-            var activeWindowInit = "a project";
-            setPresence(activeWindowInit);
+            setPresence(idling: true);
         }
 
-        public static void setPresence(string activeWindow)
+        public static void setPresence(ArchiveEditor archiveEditor = null, bool idling = false)
         {
             try
             {
+                string details = "Idling";
+                string state, largeImageKey, largeImageText, game;
+                state = largeImageKey = largeImageText = game = string.Empty;
+                string smallImageKey = "icon";
+                string smallImageText = $"Industrial Park {new IPversion().version}";
+
+                if (!idling)
+                {
+                    alreadyIdling = false;
+                    if (archiveEditor == null)
+                        // .SingleOrDefault() works best here but it's not worth throwing an
+                        // exception just to update the presence.
+                        archiveEditor = archiveEditors.Where(x => x.ContainsFocus).FirstOrDefault();
+
+                    // no point updating if it wasn't changed
+                    if (currentArchiveEditor == archiveEditor.Text)
+                        return;
+                    // additionally checking to maintain timestamp if in same level but different file
+                    if (currentArchiveEditor.Substring(0, currentArchiveEditor.Length > 4 ? 4 : currentArchiveEditor.Length) != archiveEditor.Text.Substring(0, archiveEditor.Text.Length > 4 ? 4 : archiveEditor.Text.Length))
+                    {
+                        currentTimestamp = Timestamps.Now;
+                    }
+                    currentArchiveEditor = archiveEditor.Text;
+                    
+                    game = gameHandler(archiveEditor);
+
+                    switch (game)
+                    {
+                        case "Scooby":
+                            largeImageText = "Scooby-Doo: Night of 100 Frights";
+                            break;
+                        case "BFBB":
+                            largeImageText = "SpongeBob SquarePants: Battle for Bikini Bottom";
+                            break;
+                        case "TSSM":
+                            largeImageText = "The SpongeBob SquarePants Movie Game";
+                            break;
+                        case "Incredibles":
+                            largeImageText = "The Incredibles";
+                            break;
+                        case "ROTU":
+                            largeImageText = "The Incredibles: Rise of the Underminer";
+                            break;
+                        case "Ratatouille":
+                            largeImageText = "Ratatouille (Prototype)";
+                            break;
+                        case "Unknown":
+                        default:
+                            largeImageKey = smallImageKey;
+                            largeImageText = smallImageText;
+                            smallImageKey = "";
+                            smallImageText = "";
+                            break;
+                    }
+
+                    // uses "a" or "an" depending on the game's first char.
+                    // (I = Incredibles, U = Unknown, RO = ROTU)
+                    // If no match, it's OK to prefix with "a".
+                    details = $"Editing {("IU".IndexOf(game.ElementAt(0)) >= 0 || game.StartsWith("RO") ? $"an {game}" : $"a {game}")} level";
+
+                    state = $"{archiveEditor.Text}{(archiveEditor.archive.platform != Platform.Unknown ? $" - {archiveEditor.archive.platform}" : "")}";
+                }
+                else
+                {
+                    if (alreadyIdling)
+                        return;
+                    currentArchiveEditor = string.Empty;
+                    alreadyIdling = true;
+                    currentTimestamp = Timestamps.Now;
+                    largeImageKey = smallImageKey;
+                    largeImageText = smallImageText;
+                    smallImageKey = "";
+                    smallImageText = "";
+                }
+
                 client.SetPresence(new RichPresence()
                 {
-                    Details = "Editing a Level",
-                    State = "Editing " + activeWindow,
+                    Details = details,
+                    State = state,
+                    Timestamps = currentTimestamp,
                     Assets = new Assets()
                     {
-                        LargeImageKey = "icon",
-                        LargeImageText = "Industrial Park level editor"
+                        LargeImageKey = (largeImageKey == "icon" ? largeImageKey : game.ToLower()),
+                        LargeImageText = largeImageText,
+                        SmallImageKey = smallImageKey,
+                        SmallImageText = smallImageText
                     }
                 });
             }
@@ -77,9 +161,35 @@ namespace IndustrialPark
             }
         }
 
+        private static string gameHandler(ArchiveEditor archiveEditor)
+        {
+            Game game = archiveEditor.archive.game;
+            switch (game) 
+            {
+                case Game.Scooby:
+                case Game.BFBB:
+                    return game.ToString();
+                default:
+                    switch (ArchiveEditor.GetGameFromGameConfigIni(archiveEditor.GetCurrentlyOpenFileName()))
+                    {
+                        case 3:
+                            return "TSSM";
+                        case 4:
+                            return "Incredibles";
+                        case 5:
+                            return "ROTU";
+                        case 6:
+                            return "Ratatouille";
+                        default:
+                            return "Unknown";
+                    }
+            }
+        }
+
         public static void timer1_Tick(object sender, EventArgs e)
         {
-            //timer that elapses every second to check for active window updates and adjust presence if needed
+            // timer that elapses every second to check for active window updates
+            // and adjust presence if needed
             timer1.Stop();
             GetActiveWindow();
             timer1.Start();
@@ -87,24 +197,18 @@ namespace IndustrialPark
 
         public static void GetActiveWindow()
         {
-            var activeWindowTemp = "null";
-            const int nChars = 256;
-            IntPtr handle;
-            StringBuilder Buff = new StringBuilder(nChars);
-            handle = GetForegroundWindow();
-            if (GetWindowText(handle, Buff, nChars) > 0)
+            var activeEditor = archiveEditors.Where(x => x.ContainsFocus).FirstOrDefault();
+            var activeEditorName = activeEditor?.Text;
+            if (activeEditorName != null)
             {
-                activeWindowTemp = Buff.ToString();
-            }
-            if (activeWindowTemp != "null")
-            {
-                //ensures that it only updates to archives
-                if (activeWindowTemp.EndsWith(".hip") || (activeWindowTemp.EndsWith(".hop")) || (activeWindowTemp.EndsWith(".HIP")) || (activeWindowTemp.EndsWith(".HOP")))
+                // ensures that it only updates to archives
+                if (activeEditorName.EndsWith(".hip", StringComparison.InvariantCultureIgnoreCase) || activeEditorName.EndsWith(".hop", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    var activeWindow = activeWindowTemp;
-                    setPresence(activeWindow);
+                    setPresence(activeEditor);
                 }
             }
+            else if (archiveEditors.Count == 0)
+                setPresence(idling: true);
         }
     }
 }


### PR DESCRIPTION
Redesigns the Discord Rich Presence, now looks cleaner, handles more states, and uses more images.

![Industrial Park's Rich Presence idling](https://user-images.githubusercontent.com/68174586/194422254-eca7cef2-c549-4c8b-8b2a-bd61e1e89450.png)
![Industrial Park's Rich Presence editing a N100F level](https://user-images.githubusercontent.com/68174586/194422261-3954b302-8cf7-470e-8d26-b7a326f3a595.png)

Every game has its own custom image, which appears alongside the IP logo. Again, the Discord integration is assigned to my application ID, but can be changed to any ID as long as the images match.

Additionally, this PR fixes consistent crashes for some users that have Rich Presence enabled when they encounter an error. ([see](https://discord.com/channels/446321271635050506/548372295333445642/1027654584853864480))