### PR TITLE
Update Discord RPC NuGet package

### DIFF
--- a/IndustrialPark/IndustrialPark.csproj
+++ b/IndustrialPark/IndustrialPark.csproj
@@ -72,8 +72,11 @@
     <Reference Include="AssimpNet, Version=4.1.0.0, Culture=neutral, PublicKeyToken=0d51b391f59f42a6, processorArchitecture=MSIL">
       <HintPath>..\packages\AssimpNet.4.1.0\lib\net40\AssimpNet.dll</HintPath>
     </Reference>
-    <Reference Include="DiscordRPC, Version=1.0.175.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DiscordRichPresence.1.0.175\lib\net35\DiscordRPC.dll</HintPath>
+    <Reference Include="DiscordRPC, Version=1.1.1.14, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DiscordRichPresence.1.1.1.14\lib\netstandard2.0\DiscordRPC.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.5.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAPICodePack-Core.1.1.2\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
@@ -107,6 +110,12 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Security.AccessControl, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.5.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.5.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>

--- a/IndustrialPark/MainForm/MainForm.cs
+++ b/IndustrialPark/MainForm/MainForm.cs
@@ -262,7 +262,7 @@ namespace IndustrialPark
             }
 
             // updates presence so that it doesn't get stuck on the previously focused window name
-            DiscordRPCController.setPresence(idling: true);
+            DiscordRPCController.SetPresence(idling: true);
 
             currentProjectPath = null;
             ApplyProject(new ProjectJson());
@@ -283,7 +283,7 @@ namespace IndustrialPark
             }
 
             // updates presence so that it doesn't get stuck on the previously focused window name
-            DiscordRPCController.setPresence(idling: true);
+            DiscordRPCController.SetPresence(idling: true);
 
             OpenFileDialog openFile = new OpenFileDialog()
             { Filter = "JSON files|*.json" };

--- a/IndustrialPark/Other/DiscordRPCController.cs
+++ b/IndustrialPark/Other/DiscordRPCController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using DiscordRPC;
+using DiscordRPC.Logging;
 using HipHopFile;
 
 namespace IndustrialPark
@@ -56,13 +57,16 @@ namespace IndustrialPark
             // it can be replaced with any other application ID as long as 
             // the name is "Industrial Park" and the image of the logo has 
             // the name of "icon"
-            client = new DiscordRpcClient("734104261876514836");
+            client = new DiscordRpcClient("734104261876514836")
+            {
+                Logger = new ConsoleLogger() { Level = LogLevel.Warning }
+            };
             client.Initialize();
             timer1.Start();
-            setPresence(idling: true);
+            SetPresence(idling: true);
         }
 
-        public static void setPresence(ArchiveEditor archiveEditor = null, bool idling = false)
+        public static void SetPresence(ArchiveEditor archiveEditor = null, bool idling = false)
         {
             try
             {
@@ -90,7 +94,7 @@ namespace IndustrialPark
                     }
                     currentArchiveEditor = archiveEditor.Text;
                     
-                    game = gameHandler(archiveEditor);
+                    game = GameHandler(archiveEditor);
 
                     switch (game)
                     {
@@ -161,7 +165,7 @@ namespace IndustrialPark
             }
         }
 
-        private static string gameHandler(ArchiveEditor archiveEditor)
+        private static string GameHandler(ArchiveEditor archiveEditor)
         {
             Game game = archiveEditor.archive.game;
             switch (game) 
@@ -204,11 +208,11 @@ namespace IndustrialPark
                 // ensures that it only updates to archives
                 if (activeEditorName.EndsWith(".hip", StringComparison.InvariantCultureIgnoreCase) || activeEditorName.EndsWith(".hop", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    setPresence(activeEditor);
+                    SetPresence(activeEditor);
                 }
             }
             else if (archiveEditors.Count == 0)
-                setPresence(idling: true);
+                SetPresence(idling: true);
         }
     }
 }

--- a/IndustrialPark/packages.config
+++ b/IndustrialPark/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AssimpNet" version="4.1.0" targetFramework="net48" />
-  <package id="DiscordRichPresence" version="1.0.175" targetFramework="net48" />
+  <package id="DiscordRichPresence" version="1.1.1.14" targetFramework="net48" />
+  <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net48" />
@@ -9,6 +10,8 @@
   <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net48" />
+  <package id="System.Security.AccessControl" version="4.5.0" targetFramework="net48" />
+  <package id="System.Security.Principal.Windows" version="4.5.0" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
   <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net48" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net48" />


### PR DESCRIPTION
Previous PR only served to fix crashing, not to restore proper Discord Rich Presence functionality. The errors were caused by an upstream issue in the package itself. That package has been fixed and thus has been updated to the latest version, restoring functionality.