### PR TITLE
Fix non-.RW3 textures exporting with no name

### DIFF
--- a/IndustrialPark/ArchiveEditor/ArchiveEditorFunctions_Textures.cs
+++ b/IndustrialPark/ArchiveEditor/ArchiveEditorFunctions_Textures.cs
@@ -99,6 +99,9 @@ namespace IndustrialPark
                                     }
                                     else if (name.EndsWith(".RW3"))
                                         tn.textureNativeStruct.textureName = name.Substring(0, name.Length - 4);
+                                    else
+                                        tn.textureNativeStruct.textureName = name;
+
                                     textNativeList.Add(tn);
                                 }
                     }


### PR DESCRIPTION
Currently, when you go to Edit > TXD Archive > Export (No RW3) the textures will have no name in the exported .txd file, because only textures ending in .RW3 are given a name. This PR ensures all textures have a name, whether or not they end in .RW3.